### PR TITLE
Make update seq id optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change log
 
 All notable changes to the LaunchDarkly git-flag-parser will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
+## [0.1.1] - 2019-01-10
+### Changed
+- `updateSequenceId` is now an optional parameter. If not provided (or set to a number < 0), data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`.
 
 ## [0.1.0] - 2019-01-02
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 All notable changes to the LaunchDarkly git-flag-parser will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
+
 ## [0.1.1] - 2019-01-10
 ### Changed
 - `updateSequenceId` is now an optional parameter. If not provided (or set to a number < 0), data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the LaunchDarkly git-flag-parser will be documented in th
 
 ## [0.1.1] - 2019-01-10
 ### Changed
-- `updateSequenceId` is now an optional parameter. If not provided (or set to a number < 0), data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`.
+- `updateSequenceId` is now an optional parameter. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`.
 
 ## [0.1.0] - 2019-01-02
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -53,4 +53,6 @@ publish-dev-circle-orb: validate-circle-orb
 publish-release-circle-orb: validate-circle-orb
 	circleci orb publish parse/circleci/orb.yml launchdarkly/git-flag-parser@$(TAG)
 
-.PHONY: init test lint compile-github-actions-binary compile-binary compile-bitbucket-pipelines-binary echo-release-notes publish-cli-docker publish-github-actions-docker publish-bitbucket-pipelines-docker publish-dev-circle-orb publish-release-circle-orb
+publish-all: publish-cli-docker publish-github-actions-docker publish-bitbucket-pipelines-docker publish-release-circle-orb
+
+.PHONY: init test lint compile-github-actions-binary compile-binary compile-bitbucket-pipelines-binary echo-release-notes publish-cli-docker publish-github-actions-docker publish-bitbucket-pipelines-docker publish-dev-circle-orb publish-release-circle-orb publish-all

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following options are available to the program:
 | `dir` | Path to existing checkout of the git repo. If a cloneEndpoint is provided, this option is not required. |  | only if `cloneEndpoint` is not set |
 | `exclude` | A regular expression defining the files and directories which the flag parser should exclude. |  | no |
 | `projKey` | A LaunchDarkly project key. |  | yes |
-| `updateSequenceId` | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag parser. If not provided (or set to a number < 0), data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current time. |  | no |
+| `updateSequenceId` | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag parser. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current unix timestamp. |  | no |
 | `repoHead` | The HEAD or ref to retrieve code references from. Should be provided if the `git push` was initiated on a non-master branch. | "master" | no |
 | `repoName` | Git repo name. Will be displayed in LaunchDarkly |  | yes |
 | `repoType` | The repo service provider. Used to correctly categorize repositories in the LaunchDarkly UI. Acceptable values: github\|bitbucket\|custom | "custom" | no |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The following options are available to the program:
 | `dir` | Path to existing checkout of the git repo. If a cloneEndpoint is provided, this option is not required. |  | only if `cloneEndpoint` is not set |
 | `exclude` | A regular expression defining the files and directories which the flag parser should exclude. |  | no |
 | `projKey` | A LaunchDarkly project key. |  | yes |
-| `updateSequenceId` | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag parser. Examples: the time a `git push` was initiated, CI build number, the current time. |  | yes |
+| `updateSequenceId` | An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag parser. If not provided (or set to a number < 0), data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current time. |  | no |
 | `repoHead` | The HEAD or ref to retrieve code references from. Should be provided if the `git push` was initiated on a non-master branch. | "master" | no |
 | `repoName` | Git repo name. Will be displayed in LaunchDarkly |  | yes |
 | `repoType` | The repo service provider. Used to correctly categorize repositories in the LaunchDarkly UI. Acceptable values: github\|bitbucket\|custom | "custom" | no |

--- a/parse/internal/ld/ld.go
+++ b/parse/internal/ld/ld.go
@@ -234,7 +234,7 @@ type RepoRep struct {
 type BranchRep struct {
 	Name             string              `json:"name"`
 	Head             string              `json:"head"`
-	UpdateSequenceId int64               `json:"updateSequenceId"`
+	UpdateSequenceId *int64              `json:"updateSequenceId,omitempty"`
 	SyncTime         int64               `json:"syncTime"`
 	IsDefault        bool                `json:"isDefault"`
 	References       []ReferenceHunksRep `json:"references,omitempty"`

--- a/parse/internal/options/options.go
+++ b/parse/internal/options/options.go
@@ -92,7 +92,7 @@ var options = optionMap{
 	Dir:               option{"", "Path to existing checkout of the git repo. If a cloneEndpoint is provided, this option is not required.", false},
 	Exclude:           option{"", "Exclude any files or directories that match this regular expression pattern", false},
 	ProjKey:           option{"", "LaunchDarkly project key.", true},
-	UpdateSequenceId:  option{int64(0), "An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag parser. Examples: the time a `git push` was initiated, CI build number, the current time", true},
+	UpdateSequenceId:  option{int64(-1), "An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag parser. If not provided (or set to a number < 0), data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current time.", false},
 	RepoHead:          option{"master", "The HEAD or ref to retrieve code references from.", false},
 	RepoName:          option{"", "Git repo name. Will be displayed in LaunchDarkly.", true},
 	RepoType:          option{"custom", "github|bitbucket|custom", false},

--- a/parse/internal/options/options.go
+++ b/parse/internal/options/options.go
@@ -83,16 +83,21 @@ func (m optionMap) find(name string) *option {
 	return nil
 }
 
+const (
+	noUpdateSequenceId = int64(-1)
+	noContextLines     = int64(-1)
+)
+
 var options = optionMap{
 	AccessToken:       option{"", "LaunchDarkly personal access token with write-level access.", true},
 	BaseUri:           option{"https://app.launchdarkly.com", "LaunchDarkly base URI.", false},
 	CloneEndpoint:     option{"", "If provided, will clone the repo from this endpoint. If authentication is required, this endpoint should be authenticated. Supports the https protocol for git cloning. Example: https://username:password@github.com/username/repository.git", false},
-	ContextLines:      option{-1, "The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.", false},
+	ContextLines:      option{noContextLines, "The number of context lines to send to LaunchDarkly. If < 0, no source code will be sent to LaunchDarkly. If 0, only the lines containing flag references will be sent. If > 0, will send that number of context lines above and below the flag reference. A maximum of 5 context lines may be provided.", false},
 	DefaultBranch:     option{"master", "The git default branch. The LaunchDarkly UI will default to this branch.", false},
 	Dir:               option{"", "Path to existing checkout of the git repo. If a cloneEndpoint is provided, this option is not required.", false},
 	Exclude:           option{"", "Exclude any files or directories that match this regular expression pattern", false},
 	ProjKey:           option{"", "LaunchDarkly project key.", true},
-	UpdateSequenceId:  option{int64(-1), "An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag parser. If not provided (or set to a number < 0), data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current time.", false},
+	UpdateSequenceId:  option{noUpdateSequenceId, "An integer representing the order number of code reference updates. Used to version updates across concurrent executions of the flag parser. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`. Examples: the time a `git push` was initiated, CI build number, the current unix timestamp.", false},
 	RepoHead:          option{"master", "The HEAD or ref to retrieve code references from.", false},
 	RepoName:          option{"", "Git repo name. Will be displayed in LaunchDarkly.", true},
 	RepoType:          option{"custom", "github|bitbucket|custom", false},

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -40,7 +40,7 @@ type branch struct {
 	Name             string
 	Head             string
 	IsDefault        bool
-	UpdateSequenceId int64
+	UpdateSequenceId *int64
 	SyncTime         int64
 	GrepResults      grepResultLines
 }
@@ -98,10 +98,15 @@ func Parse() {
 	}
 
 	ctxLines := o.ContextLines.Value()
+	var updateId *int64
+	if o.UpdateSequenceId.Value() >= 0 {
+		updateIdOption := o.UpdateSequenceId.Value()
+		updateId = &updateIdOption
+	}
 	b := &branch{
 		Name:             currBranch,
 		IsDefault:        o.DefaultBranch.Value() == currBranch,
-		UpdateSequenceId: o.UpdateSequenceId.Value(),
+		UpdateSequenceId: updateId,
 		SyncTime:         makeTimestamp(),
 		Head:             headSha,
 	}


### PR DESCRIPTION
Alters the `updateSequenceId` parameter to be optional. If not provided (or set to a number < 0), data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new.