### PR TITLE
Don't grep for flags with short keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 All notable changes to the LaunchDarkly git-flag-parser will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
-## [0.1.1] - 2019-01-10
+## [0.1.1] - 2019-01-11
 ### Changed
 - `updateSequenceId` is now an optional parameter. If not provided, data will always be updated. If provided, data will only be updated if the existing `updateSequenceId` is less than the new `updateSequenceId`.
+- Flags with keys shorter than 3 characters are no longer supported.
 
 ## [0.1.0] - 2019-01-02
 ### Changed

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -108,10 +108,15 @@ func Parse() {
 	}
 
 	ctxLines := o.ContextLines.Value()
+	var updateId *int64
+	if o.UpdateSequenceId.Value() >= 0 {
+		updateIdOption := o.UpdateSequenceId.Value()
+		updateId = &updateIdOption
+	}
 	b := &branch{
 		Name:             currBranch,
 		IsDefault:        o.DefaultBranch.Value() == currBranch,
-		UpdateSequenceId: o.UpdateSequenceId.Value(),
+		UpdateSequenceId: updateId,
 		SyncTime:         makeTimestamp(),
 		Head:             headSha,
 	}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -832,3 +832,40 @@ func Test_groupIntoPathMap(t *testing.T) {
 	require.Equal(t, bLines.Front().Value, grepResultPathBLine1)
 	require.Equal(t, bLines.Back().Value, grepResultPathBLine2)
 }
+
+func Test_filterShortFlags(t *testing.T) {
+	// Note: these specs assume minFlagKeyLen is 3
+	tests := []struct {
+		name  string
+		flags []string
+		want  []string
+	}{
+		{
+			name:  "Empty input/output",
+			flags: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "all flags are too short",
+			flags: []string{"a", "b"},
+			want:  []string{},
+		},
+		{
+			name:  "some flags are too short",
+			flags: []string{"abcdefg", "b", "ab", "abc"},
+			want:  []string{"abcdefg", "abc"},
+		},
+		{
+			name:  "no flags are too short",
+			flags: []string{"catsarecool", "dogsarecool"},
+			want:  []string{"catsarecool", "dogsarecool"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterShortFlagKeys(tt.flags)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Flags with really short keys like `a` or `ab` end up generating many
false positives, drowning out real code references with noise. For now
we will just not support those flags for code references.

I wonder if we should allow users to override this minimum with a CLI param? I'm leaning towards waiting for if/when someone requests that feature.

TODO:
- [ ] documentation