### PR TITLE
Fix type of default contextLines option

### DIFF
--- a/parse/internal/options/options.go
+++ b/parse/internal/options/options.go
@@ -85,7 +85,7 @@ func (m optionMap) find(name string) *option {
 
 const (
 	noUpdateSequenceId = int64(-1)
-	noContextLines     = int64(-1)
+	noContextLines     = -1
 )
 
 var options = optionMap{


### PR DESCRIPTION
This snuck in with one of the recent PRs. We missed it because the option parser does a lot of type assertions.