### PR TITLE
Limit number of files, and number of hunked lines per file/flag pair.

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -394,7 +394,6 @@ func buildHunksForFlag(projKey, flag string, flagReferences []*list.Element, fil
 			currentHunk.Lines = hunkStringBuilder.String()
 			hunks = append(hunks, currentHunk)
 			previousHunk = &hunks[len(hunks)-1]
-
 		}
 
 		// If we have written more than the max. allowed number of lines for this file and flag, finish this hunk and exit early.

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -15,6 +15,11 @@ import (
 	o "github.com/launchdarkly/git-flag-parser/parse/internal/options"
 )
 
+// These are defensive limits intended to prevent corner cases stemming from
+// large repos, false positives, etc. The goal is a) to prevent the parser
+// from taking a very long time to run and b) to prevent the parser from
+// PUTing a massive json payload. These limits will likely be tweaked over
+// time. The LaunchDarkly backend will also apply limits.
 const minFlagKeyLen = 3
 const maxFileCount = 5000
 const maxLineCharCount = 500

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -17,6 +17,7 @@ import (
 )
 
 const minFlagKeyLen = 3
+const maxFileCount = 1000
 const maxLineCharCount = 500
 
 type grepResultLine struct {
@@ -229,6 +230,12 @@ func (g grepResultLines) makeReferenceHunksReps(projKey string, ctxLines int) []
 	reps := []ld.ReferenceHunksRep{}
 
 	aggregatedGrepResults := g.aggregateByPath()
+
+	if len(aggregatedGrepResults) > maxFileCount {
+		log.Info("number of files containing code references exceeded limit",
+			log.Field("number of matched files", len(aggregatedGrepResult)), log.Field("file limit", maxFileCount))
+		aggregatedGrepResults = aggregatedGrepResults[0:maxFileCount]
+	}
 
 	for _, fileGrepResults := range aggregatedGrepResults {
 		hunks := fileGrepResults.makeHunkReps(projKey, ctxLines)

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -336,7 +336,6 @@ func buildHunksForFlag(projKey, flag string, flagReferences []*list.Element, fil
 	appendToPreviousHunk := false
 
 	numHunkedLines := 0
-	exceededLineLimit := false
 
 	for _, ref := range flagReferences {
 		// Each ref is either the start of a new hunk or a continuation of the previous hunk.
@@ -388,26 +387,19 @@ func buildHunksForFlag(projKey, flag string, flagReferences []*list.Element, fil
 			}
 		}
 
-		// If we have written more than the max. allowed number of lines for this file and flag, finish this hunk and exit early.
-		// This guards against a situation where the user has very long files with many false positive matches.
-		if numHunkedLines > maxHunkedLinesPerFileAndFlagCount {
-			exceededLineLimit = true
-		}
-
 		if appendToPreviousHunk {
 			previousHunk.Lines = hunkStringBuilder.String()
 			appendToPreviousHunk = false
+		} else {
+			currentHunk.Lines = hunkStringBuilder.String()
+			hunks = append(hunks, currentHunk)
+			previousHunk = &hunks[len(hunks)-1]
 
-			if !exceededLineLimit {
-				continue
-			}
 		}
 
-		currentHunk.Lines = hunkStringBuilder.String()
-		hunks = append(hunks, currentHunk)
-		previousHunk = &hunks[len(hunks)-1]
-
-		if exceededLineLimit {
+		// If we have written more than the max. allowed number of lines for this file and flag, finish this hunk and exit early.
+		// This guards against a situation where the user has very long files with many false positive matches.
+		if numHunkedLines > maxHunkedLinesPerFileAndFlagCount {
 			log.Info("Exceeded permitted number of flag reference lines + context lines for file",
 				map[string]interface{}{"flag": flag, "limit": maxHunkedLinesPerFileAndFlagCount})
 			return hunks


### PR DESCRIPTION
I've tested all these limits by cranking them down and running the command against SupportService.

Note that we can't actually calculate the upper bound payload limit from these numbers because size will depend on number of flags.

https://app.clubhouse.io/launchdarkly/story/27365/add-a-minimum-character-limit-for-flags-scanned-by-the-git-flag-parser-and-other-limits