### PR TITLE
Use case sensitive ag search.

### DIFF
--- a/parse/internal/git/git.go
+++ b/parse/internal/git/git.go
@@ -59,7 +59,7 @@ func (g Git) Checkout() error {
 func (g Git) Grep(flags []string, ctxLines int) ([][]string, error) {
 	var sb strings.Builder
 
-	sb.WriteString(fmt.Sprintf("ag --nogroup"))
+	sb.WriteString(fmt.Sprintf("ag --nogroup --case-sensitive"))
 	if ctxLines > 0 {
 		sb.WriteString(fmt.Sprintf(" -C%d", ctxLines))
 	}


### PR DESCRIPTION
This is a must for the downstream parsing code to work properly.